### PR TITLE
Add local API key file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ pip install -r requirements.txt
 python normalize_statement.py path/to/statement.csv -o normalized.csv
 ```
 
+The script looks for the OpenAI API key in the `OPENAI_API_KEY` environment
+variable. Alternatively you can place the key in a file named
+`.openai_api_key` either in the repository root or in your home directory and
+it will be loaded automatically.
+
 The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
 is sent to the OpenAI API to clean up the merchant name and determine the most
 likely spending category. The output CSV contains the columns `Date`, `Merchant`,

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -96,10 +96,26 @@ for _kw, (cat, subcat) in KEYWORD_MAP.items():
     CATEGORIES.setdefault(cat, set()).add(subcat)
 
 
+def load_api_key():
+    """Load the OpenAI API key from env or local files."""
+    if openai.api_key:
+        return
+
+    key = os.getenv("OPENAI_API_KEY")
+    if key:
+        openai.api_key = key.strip()
+        return
+
+    for path in [".openai_api_key", os.path.expanduser("~/.openai_api_key")]:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                openai.api_key = fh.read().strip()
+            return
+
+
 def openai_normalize(desc: str, date, amount):
     """Use OpenAI to clean merchant name and classify the transaction."""
-    if not openai.api_key:
-        openai.api_key = os.getenv("OPENAI_API_KEY", "")
+    load_api_key()
 
     cats = "\n".join(
         f"- {cat}: {', '.join(sorted(subs))}" for cat, subs in CATEGORIES.items()


### PR DESCRIPTION
## Summary
- support loading OpenAI API key from `.openai_api_key` file
- document local key file in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile normalize_statement.py`
- `python normalize_statement.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6843d833b7f08327bf78c90d1307d2fe