### PR TITLE
Add debug logging and update OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ variable. Alternatively you can place the key in a file named
 `.openai_api_key` either in the repository root or in your home directory and
 it will be loaded automatically.
 
+The script now defaults to the `gpt-4o-mini` model. Set the `OPENAI_MODEL`
+environment variable to override this.
+
 The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
 is sent to the OpenAI API to clean up the merchant name and determine the most
 likely spending category. The output CSV contains the columns `Date`, `Merchant`,


### PR DESCRIPTION
## Summary
- default to `gpt-4o-mini` model
- add verbose debug logging and new `--verbose` CLI flag
- allow overriding model via `OPENAI_MODEL` env var
- document new model and environment variable

## Testing
- `python -m py_compile normalize_statement.py`
- `python normalize_statement.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6843dd9cb0188327a30cc40a31618840