### PR TITLE
Improve OpenAI API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ variable. Alternatively you can place the key in a file named
 `.openai_api_key` either in the repository root or in your home directory and
 it will be loaded automatically.
 
+If the key cannot be located, the script will now raise a clear error
+explaining how to provide it.
+
 The script now defaults to the `gpt-4o-mini` model. Set the `OPENAI_MODEL`
 environment variable to override this.
 

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -118,19 +118,24 @@ def load_api_key():
     """Load the OpenAI API key from env or local files."""
     if openai.api_key:
         os.environ.setdefault("OPENAI_API_KEY", openai.api_key)
-        return
+        return openai.api_key
 
     key = os.getenv("OPENAI_API_KEY")
     if key:
         openai.api_key = key.strip()
-        return
+        return openai.api_key
 
     for path in [".openai_api_key", os.path.expanduser("~/.openai_api_key")]:
         if os.path.exists(path):
             with open(path, "r", encoding="utf-8") as fh:
                 openai.api_key = fh.read().strip()
             os.environ["OPENAI_API_KEY"] = openai.api_key
-            return
+            return openai.api_key
+
+    raise RuntimeError(
+        "OpenAI API key not found. Set the OPENAI_API_KEY environment variable or "
+        "create a .openai_api_key file."
+    )
 
 
 def openai_normalize(desc: str, date, amount):


### PR DESCRIPTION
## Summary
- raise a clear error when the OpenAI API key is missing
- document that the script will fail with an error if no key is found

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843e34de9d8832797cbbce589dd2bde