### PR TITLE
Add retries for OpenAI rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ explaining how to provide it.
 The script now defaults to the `gpt-4o-mini` model. Set the `OPENAI_MODEL`
 environment variable to override this.
 
+If the OpenAI API returns a rate limit or other transient error, the script
+automatically retries the request with exponential backoff.
+
 The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
 is sent to the OpenAI API to clean up the merchant name and determine the most
 likely spending category. The output CSV contains the columns `Date`, `Merchant`,


### PR DESCRIPTION
## Summary
- retry OpenAI API calls with exponential backoff when hitting rate limits
- mention automatic retries in README

## Testing
- `python normalize_statement.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6843e46350748327b3c31fd0dff9bea4