### PR TITLE
Update default model for free users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ it will be loaded automatically.
 If the key cannot be located, the script will now raise a clear error
 explaining how to provide it.
 
-The script now defaults to the `gpt-4o-mini` model. Set the `OPENAI_MODEL`
-environment variable to override this.
+The script now defaults to the `gpt-3.5-turbo` model, which is available for
+free tier users. Set the `OPENAI_MODEL` environment variable to override this.
 
 The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
 is sent to the OpenAI API to clean up the merchant name and determine the most

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -6,7 +6,7 @@ import logging
 import openai
 import pandas as pd
 
-MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- default to `gpt-3.5-turbo` instead of `gpt-4o-mini`
- document that the script is free-tier friendly

## Testing
- `python -m py_compile normalize_statement.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6843e534fb4c8327bd4cadc064629422