### PR TITLE
Refactor OpenAI retries with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The script now defaults to the `gpt-3.5-turbo` model, which is available for
 free tier users. Set the `OPENAI_MODEL` environment variable to override this.
 
 If the OpenAI API returns a rate limit or other transient error, the script
-automatically retries the request with exponential backoff.
+automatically retries the request with exponential backoff using the `backoff`
+library.
 
 The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
 is sent to the OpenAI API to clean up the merchant name and determine the most

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -4,6 +4,7 @@ import os
 import logging
 import time
 
+import backoff
 import openai
 import pandas as pd
 
@@ -139,28 +140,20 @@ def load_api_key():
     )
 
 
-def _chat_with_retry(messages, max_retries: int = 5):
+@backoff.on_exception(
+    backoff.expo,
+    (openai.error.RateLimitError, openai.error.APIError),
+    max_tries=5,
+    logger=logger,
+)
+def _chat_with_retry(messages):
     """Call OpenAI with exponential backoff on rate limit errors."""
-    delay = 1
-    for attempt in range(max_retries):
-        try:
-            resp = openai.chat.completions.create(
-                model=MODEL,
-                messages=messages,
-                temperature=0,
-            )
-            return resp.choices[0].message.content
-        except openai.RateLimitError:
-            logger.warning("Rate limit hit, retrying in %s seconds", delay)
-        except openai.APIError as exc:
-            logger.warning("OpenAI API error: %s. Retrying in %s seconds", exc, delay)
-        except Exception:
-            logger.exception("OpenAI API call failed")
-            return None
-        time.sleep(delay)
-        delay = min(delay * 2, 60)
-    logger.error("Exceeded maximum OpenAI retries")
-    return None
+    resp = openai.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0,
+    )
+    return resp.choices[0].message.content
 
 
 def openai_normalize(desc: str, date, amount):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 openai
+backoff


### PR DESCRIPTION
## Summary
- use the `backoff` library for retries when calling OpenAI
- mention `backoff` usage in the README
- add backoff to requirements

## Testing
- `python -m py_compile normalize_statement.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e6076d648327b01cfd978cc801e9