### PR TITLE
Update default model to GPT-4.1 nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ it will be loaded automatically.
 If the key cannot be located, the script will now raise a clear error
 explaining how to provide it.
 
-The script now defaults to the `gpt-3.5-turbo` model, which is available for
+The script now defaults to the `gpt-4.1-nano` model, which is available for
 free tier users. Set the `OPENAI_MODEL` environment variable to override this.
 
 If the OpenAI API returns a rate limit or other transient error, the script

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -8,7 +8,7 @@ import backoff
 import openai
 import pandas as pd
 
-MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-nano")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- set `gpt-4.1-nano` as the default model in the script
- document the new default model in README

## Testing
- `python -m py_compile normalize_statement.py`

------
https://chatgpt.com/codex/tasks/task_e_6843e947c39883279977feb2e615a6e8