### PR TITLE
Fix JSON parsing of OpenAI responses

### DIFF
--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -187,6 +187,18 @@ def openai_normalize(desc: str, date, amount):
         ]
     )
     content = content.strip() if content else ""
+
+    # Newer models sometimes wrap the JSON response in a Markdown code block
+    # when asked for a structured reply. Strip these markers if present so the
+    # result can be parsed correctly.
+    if content.startswith("```"):
+        # Extract text between the first and last code fences
+        import re
+
+        match = re.search(r"```(?:json)?\n?(.*?)```", content, re.DOTALL)
+        if match:
+            content = match.group(1).strip()
+
     if not content:
         return desc, *categorize(desc)
 


### PR DESCRIPTION
## Summary
- handle OpenAI responses wrapped in ```json code blocks

## Testing
- `python -m py_compile budget/normalize_statement.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ebeb092c83278d60494b9a819e20