### PR TITLE
Update default model and refine prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ it will be loaded automatically.
 If the key cannot be located, the script will now raise a clear error
 explaining how to provide it.
 
-The script now defaults to the `gpt-4o-mini` model, which is available for
-free tier users. Set the `OPENAI_MODEL` environment variable to override this.
+The script now defaults to the `gpt-4.1-nano` model. Set the `OPENAI_MODEL`
+environment variable to override this.
 
 If the OpenAI API returns a rate limit or other transient error, the script
 automatically retries the request with exponential backoff using the `backoff`

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -15,7 +15,7 @@ import backoff
 import openai
 import pandas as pd
 
-DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1-nano")
 
 logger = logging.getLogger(__name__)
 
@@ -142,10 +142,9 @@ def build_categories_string() -> str:
 def build_prompt(desc: str, date, amount) -> str:
     """Construct the user prompt sent to OpenAI."""
     return (
-        "Clean up the merchant name, try to infer the company behind the charge,"
-        " and classify the transaction into one of the following categories and"
-        " subcategories. Respond in JSON with keys 'company', 'category', and"
-        " 'subcategory'.\n\n"
+        "Clean up the merchant name, infer the company, and classify the charge. "
+        "Treat any 'AplPay' or 'Apple Pay' tag as the payment method, not part of the company name. "
+        "Respond in JSON with keys 'company', 'category', and 'subcategory'.\n\n"
         f"Date: {date}\nDescription: {desc}\nAmount: {amount}\n\nCategories:\n{build_categories_string()}"
     )
 


### PR DESCRIPTION
## Summary
- switch default model to `gpt-4.1-nano`
- adjust prompt to handle Apple Pay descriptions
- update docs for new default model

## Testing
- `python -m py_compile normalize_statement.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f76ecbf48327994df1e75152d01f