### PR TITLE
Refactor to sequential normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a small Python script to normalize credit card statemen
 pip install -r requirements.txt
 ```
 
-The script uses the OpenAI Batch API which requires `openai>=1.24.0`.
+The script uses the OpenAI Chat API which requires `openai>=1.24.0`.
 
 ## Usage
 
@@ -31,9 +31,9 @@ To avoid parse errors the script now requests structured responses from
 OpenAI using the `response_format` parameter so the model always returns a
 valid JSON object.
 
-The input CSV must have the columns `Date`, `Description`, and `Amount`. All rows
-are sent together using the OpenAI Batch API to clean up the merchant name,
-infer the company, and determine the most likely spending category. When
+The input CSV must have the columns `Date`, `Description`, and `Amount`. Each row
+is sent sequentially to the Chat API to clean up the merchant name, infer the company,
+and determine the most likely spending category. When
 available, the inferred company name is used in the `Description` column. The
 output CSV contains the columns `Date`, `Description`, `Amount`, `Category`,
 and `Subcategory`.


### PR DESCRIPTION
## Summary
- remove use of OpenAI Batch API
- send each transaction sequentially with retries and backoff
- document switch to Chat API in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile normalize_statement.py`
- `python normalize_statement.py -h`


------
https://chatgpt.com/codex/tasks/task_e_6843f94d44bc8327acc49a8b6c1d9c53