### PR TITLE
Improve prompt instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ valid JSON object.
 The script reads any CSV format and sends each row's data to the Chat API for
 classification. The model is asked to infer the transaction date and amount from
 the available columns, clean up the merchant name, and determine the spending
-category. The resulting CSV contains only five fields: `Date`, `Company`,
-`Amount`, `Category`, and `Subcategory`.
+category. Categories and subcategories are chosen from a fixed list. If no
+category fits, the model will use `Uncategorized` for both fields. The resulting
+CSV contains only five fields: `Date`, `Company`, `Amount`, `Category`, and
+`Subcategory`.
 

--- a/normalize_statement.py
+++ b/normalize_statement.py
@@ -146,7 +146,9 @@ def build_prompt(row: pd.Series) -> str:
         "and amount from these columns. Treat any 'AplPay' or 'Apple Pay' tag as the payment "
         "method, not part of the company name. Remove location references like country or state. "
         "Classify the charge using the categories provided and respond in JSON with keys "
-        "'date', 'company', 'amount', 'category', and 'subcategory'.\n\n"
+        "'date', 'company', 'amount', 'category', and 'subcategory'. The 'category' must exactly "
+        "match one of the categories below and 'subcategory' must be one of that category's "
+        "listed subcategories. If nothing fits, use 'Uncategorized' for both fields.\n\n"
         f"{row_details}\n\nCategories:\n{build_categories_string()}"
     )
 


### PR DESCRIPTION
## Summary
- emphasize that the model must pick category/subcategory from the provided lists
- note that the README clarifies use of `Uncategorized` if no match exists

## Testing
- `python -m py_compile normalize_statement.py`
- `python normalize_statement.py -h`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6857526ae1588327b9da0e1b2562cd8d